### PR TITLE
🔀 :: (#168) mac 로그인 시 device token 처리

### DIFF
--- a/user-domain/src/main/kotlin/com/xquare/v1userservice/user/api/impl/UserApiImpl.kt
+++ b/user-domain/src/main/kotlin/com/xquare/v1userservice/user/api/impl/UserApiImpl.kt
@@ -150,7 +150,7 @@ class UserApiImpl(
         val deviceTokenModifiedUser = if (signInDomainRequest.deviceToken != "mac") {
             userRepositorySpi.applyChanges(user.setDeviceToken(signInDomainRequest.deviceToken))
         } else {
-            userRepositorySpi.applyChanges(user)
+            user
         }
 
         checkPasswordMatches(deviceTokenModifiedUser, signInDomainRequest.password)

--- a/user-domain/src/main/kotlin/com/xquare/v1userservice/user/api/impl/UserApiImpl.kt
+++ b/user-domain/src/main/kotlin/com/xquare/v1userservice/user/api/impl/UserApiImpl.kt
@@ -147,8 +147,11 @@ class UserApiImpl(
         val user = userRepositorySpi.findByAccountIdAndStateWithCreated(signInDomainRequest.accountId)
             ?: throw UserNotFoundException(UserNotFoundException.USER_ID_NOT_FOUND)
 
-        val deviceTokenModifiedUser =
+        val deviceTokenModifiedUser = if (signInDomainRequest.deviceToken != "mac") {
             userRepositorySpi.applyChanges(user.setDeviceToken(signInDomainRequest.deviceToken))
+        } else {
+            userRepositorySpi.applyChanges(user)
+        }
 
         checkPasswordMatches(deviceTokenModifiedUser, signInDomainRequest.password)
 


### PR DESCRIPTION
클라에서 macOS일 경우 "mac" 을 보내는 것으로 합의 후,
"mac"으로 올 시에 devicetoken을 저장하지 않는 로직으로 변경하였습니다