### PR TITLE
🔀 :: (#209) 로그인 실패 시, 디바이스 토큰 변경 버그 수정

### DIFF
--- a/user-domain/src/main/kotlin/com/xquare/v1userservice/user/api/impl/UserApiImpl.kt
+++ b/user-domain/src/main/kotlin/com/xquare/v1userservice/user/api/impl/UserApiImpl.kt
@@ -147,13 +147,11 @@ class UserApiImpl(
         val user = userRepositorySpi.findByAccountIdAndStateWithCreated(signInDomainRequest.accountId)
             ?: throw UserNotFoundException(UserNotFoundException.USER_ID_NOT_FOUND)
 
-        val deviceTokenModifiedUser = if (signInDomainRequest.deviceToken != "mac") {
-            userRepositorySpi.applyChanges(user.setDeviceToken(signInDomainRequest.deviceToken))
-        } else {
-            user
-        }
+        checkPasswordMatches(user, signInDomainRequest.password)
 
-        checkPasswordMatches(deviceTokenModifiedUser, signInDomainRequest.password)
+        if (signInDomainRequest.deviceToken != "mac") {
+            userRepositorySpi.applyChanges(user.setDeviceToken(signInDomainRequest.deviceToken))
+        }
 
         val params = buildAccessTokenParams(user)
 


### PR DESCRIPTION
- 비밀번호 비교 후에 mac이 아닐 경우 디바이스 토큰 변경하는 로직으로 수정