### PR TITLE
🔀 :: secret value 삭제

### DIFF
--- a/user-infrastructure/src/main/kotlin/com/xquare/v1userservice/user/aop/RequestHeaderAspect.kt
+++ b/user-infrastructure/src/main/kotlin/com/xquare/v1userservice/user/aop/RequestHeaderAspect.kt
@@ -1,7 +1,6 @@
 package com.xquare.v1userservice.user.aop
 
 import com.xquare.v1userservice.jwt.UnAuthorizedException
-import com.xquare.v1userservice.user.exceptions.InvalidSecretValueException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest

--- a/user-infrastructure/src/main/kotlin/com/xquare/v1userservice/user/aop/RequestHeaderAspect.kt
+++ b/user-infrastructure/src/main/kotlin/com/xquare/v1userservice/user/aop/RequestHeaderAspect.kt
@@ -19,11 +19,4 @@ class RequestHeaderAspect(
 
         return UUID.fromString(userId)
     }
-
-    fun getSecretValue(serverRequest: ServerRequest) {
-        val secretValue = serverRequest.headers().firstHeader("Request-Xquare-Secret")
-        if ((secretValue == null) || (secretValue != secret)) {
-            throw InvalidSecretValueException("Secret is invalid")
-        }
-    }
 }

--- a/user-infrastructure/src/main/kotlin/com/xquare/v1userservice/user/router/UserHandler.kt
+++ b/user-infrastructure/src/main/kotlin/com/xquare/v1userservice/user/router/UserHandler.kt
@@ -91,7 +91,6 @@ class UserHandler(
 
     suspend fun getUserByIdHandler(serverRequest: ServerRequest): ServerResponse {
         val userId = serverRequest.pathVariable("userId")
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val user = userApi.getUserById(UUID.fromString(userId))
         val userResponseDto = user.toGetUserByAccountIdResponseDto()
@@ -102,7 +101,6 @@ class UserHandler(
     suspend fun getUserByIdsInHandler(serverRequest: ServerRequest): ServerResponse {
         val userIds = serverRequest.queryParams()["userId"]?.map { UUID.fromString(it) }
             ?: throw BadRequestException("userId is required")
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val users = userApi.getUsersByIdsIn(userIds)
         val userResponseDtos = users.map { it.toGetUserByAccountIdResponseDto() }
@@ -112,7 +110,6 @@ class UserHandler(
 
     suspend fun getUserByIdsToBodyHandler(serverRequest: ServerRequest): ServerResponse {
         val userIds = serverRequest.getUserInfoRequestBody()
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val users = userApi.getUsersByIdsIn(userIds.userIds)
         val userResponseDtos = users.map { it.toGetUserByAccountIdResponseDto() }
@@ -125,7 +122,6 @@ class UserHandler(
 
     suspend fun getUserByAccountIdHandler(serverRequest: ServerRequest): ServerResponse {
         val accountId = serverRequest.pathVariable("accountId")
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val user = userApi.getUserByAccountId(accountId)
         val userResponseDto = user.toGetUserByAccountIdResponseDto()
@@ -165,7 +161,6 @@ class UserHandler(
 
     suspend fun getUserDeviceTokensHandler(serverRequest: ServerRequest): ServerResponse {
         val userIds = serverRequest.getUserIdList().awaitSingle().userIdList
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val userDeviceTokenDomainResponse = userApi.getUserDeviceTokensByIdIn(userIds)
         val getUserDeviceTokenListResponse = userDeviceTokenDomainResponse.toGetUserDeviceTokenListResponse()
@@ -204,7 +199,6 @@ class UserHandler(
         val grade = serverRequest.queryParams().getFirst("grade")?.toIntOrNull()
             ?: throw BadRequestException("grade is required")
         val classNum = serverRequest.queryParams().getFirst("classNum")?.toIntOrNull()
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val users = userApi.getUserByGradeAndClass(grade, classNum)
         val userResponse = users.map { it.toGetUserGradeAndClass() }
@@ -223,7 +217,6 @@ class UserHandler(
     }
 
     suspend fun getAllStudentHandler(serverRequest: ServerRequest): ServerResponse {
-        requestHeaderAspect.getSecretValue(serverRequest)
         val users = userApi.getAllStudent()
         val userResponseDtos = users.map { it.toGetUserByAccountIdResponseDto() }
         val userListResponse = GetUserListResponse(userResponseDtos)
@@ -232,7 +225,6 @@ class UserHandler(
     }
 
     suspend fun getAllTeacherHandler(serverRequest: ServerRequest): ServerResponse {
-        requestHeaderAspect.getSecretValue(serverRequest)
         val teachers = userApi.getAllTeacher()
         val teacherInfoResponse = teachers.map { it.toGetTeacherInfoResponseDto() }
         val teacherResponse = GetTeacherResponse(teacherInfoResponse)
@@ -242,7 +234,6 @@ class UserHandler(
 
     suspend fun getAllStudentByNameHandler(serverRequest: ServerRequest): ServerResponse {
         val name = serverRequest.queryParam("name").orElse("")
-        requestHeaderAspect.getSecretValue(serverRequest)
 
         val users = userApi.getAllStudentByName(name)
         val userResponse = users.map { it.toGetUserNameResponseDto() }
@@ -252,7 +243,6 @@ class UserHandler(
 
     suspend fun getUserByRoleHandler(serverRequest: ServerRequest): ServerResponse {
         val role = serverRequest.queryParams().getFirst("roleName") ?: throw BadRequestException("roleName is required")
-        requestHeaderAspect.getSecretValue(serverRequest)
         checkUserRole(role)
 
         val users = userApi.getAllUserByRole(role)
@@ -283,7 +273,6 @@ class UserHandler(
     }
 
     suspend fun getExcludeUserListHandler(serverRequest: ServerRequest): ServerResponse {
-        requestHeaderAspect.getSecretValue(serverRequest)
         val excludeUserIds = serverRequest.getUserIdList().awaitSingle().userIdList.nullIfBlank()?.map { it }
         val users = userApi.getExcludeUserIdList(excludeUserIds)
         val response = ExcludeUserIdListResponse(users)


### PR DESCRIPTION
서버끼리 통신하는 API 들이 중요힌 정보가 담겨있는 것들이 많아서 아무나 호출하는 것을 막기 위해서 나온 방안이

SQS 혹은 secret value 였는데 sqs 라이브러리를 만들 계획이 있기도 했고,
secret value의 경우, 서버만 통신하는 API가 있는 레포라면 코드가 겹치는 부분이 많아서
확장성을 고려한다면 라이브러리를 만들어서 사용하는 것이 좋을 것 같다고 의견 통합이 되어서 sqs를 사용하는 것으로 되었습니다